### PR TITLE
Added a date picker controller

### DIFF
--- a/SwiftHelpers.xcodeproj/project.pbxproj
+++ b/SwiftHelpers.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		9C3D7BC91D2A64C40017B3D6 /* SHRightImageButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C3D7BC81D2A64C40017B3D6 /* SHRightImageButton.swift */; };
 		9C3D7BCB1D2A65370017B3D6 /* SHSeparatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C3D7BCA1D2A65370017B3D6 /* SHSeparatorView.swift */; };
 		9C3D7BD01D2A67FB0017B3D6 /* SHNSObjectExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C3D7BCE1D2A66DE0017B3D6 /* SHNSObjectExtensionTests.swift */; };
+		9C6B88131D630D7F00AF5004 /* SHDatePickerController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C6B88121D630D7F00AF5004 /* SHDatePickerController.swift */; };
 		B045E7E11A695EA700046449 /* SwiftHelpers.podspec in Resources */ = {isa = PBXBuildFile; fileRef = B045E7E01A695EA700046449 /* SwiftHelpers.podspec */; };
 		B09F59751B4204AB00EB9220 /* DateProximityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B09F59741B4204AB00EB9220 /* DateProximityTests.swift */; };
 		B0BF98E61A667CFA0085ADA4 /* SwiftHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = B0BF98E51A667CFA0085ADA4 /* SwiftHelpers.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -114,6 +115,7 @@
 		9C3D7BC81D2A64C40017B3D6 /* SHRightImageButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SHRightImageButton.swift; sourceTree = "<group>"; };
 		9C3D7BCA1D2A65370017B3D6 /* SHSeparatorView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SHSeparatorView.swift; sourceTree = "<group>"; };
 		9C3D7BCE1D2A66DE0017B3D6 /* SHNSObjectExtensionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SHNSObjectExtensionTests.swift; sourceTree = "<group>"; };
+		9C6B88121D630D7F00AF5004 /* SHDatePickerController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SHDatePickerController.swift; sourceTree = "<group>"; };
 		B045E7E01A695EA700046449 /* SwiftHelpers.podspec */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = SwiftHelpers.podspec; sourceTree = "<group>"; };
 		B053A0071AC353D700278644 /* StringExtensionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringExtensionTests.swift; sourceTree = "<group>"; };
 		B066D6851A7646900069C258 /* UIColorExtensionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIColorExtensionTests.swift; sourceTree = "<group>"; };
@@ -244,6 +246,7 @@
 				584150A71D61F51200866210 /* SHCoreDataStack.swift */,
 				B0BF98EF1A667CFA0085ADA4 /* SwiftHelpersTests */,
 				B0BF98E31A667CFA0085ADA4 /* Supporting Files */,
+				9C6B88121D630D7F00AF5004 /* SHDatePickerController.swift */,
 			);
 			path = SwiftHelpers;
 			sourceTree = "<group>";
@@ -415,6 +418,7 @@
 				B0DBC97D1B41FB340097E59E /* SHDateFormatterProximity.swift in Sources */,
 				9C3D7BC71D2A640E0017B3D6 /* SHGradientView.swift in Sources */,
 				586C82E41C2421BF00590E17 /* SHNavigationControllerExtention.swift in Sources */,
+				9C6B88131D630D7F00AF5004 /* SHDatePickerController.swift in Sources */,
 				58691B671CCE09E80056D78E /* SHNotificationExtension.swift in Sources */,
 				9C3D7BCB1D2A65370017B3D6 /* SHSeparatorView.swift in Sources */,
 				5840FD6D1D34E60500EDE37B /* SHGif.swift in Sources */,

--- a/SwiftHelpers/SHDatePickerController.swift
+++ b/SwiftHelpers/SHDatePickerController.swift
@@ -8,6 +8,8 @@
 
 import UIKit
 
+#if os(iOS)
+
 /*
 ** A view controller responsible for presenting a date picker to the user
 ** and pass back the selected date.
@@ -195,3 +197,5 @@ public class SHDatePickerAnimatedTransition: NSObject, UIViewControllerAnimatedT
     }
     
 }
+
+#endif

--- a/SwiftHelpers/SHDatePickerController.swift
+++ b/SwiftHelpers/SHDatePickerController.swift
@@ -119,10 +119,10 @@ public class SHDatePickerViewController: UIViewController {
 /// A class used to animate the transition of a SHDatePickerViewController
 public class SHDatePickerAnimatedTransition: NSObject, UIViewControllerAnimatedTransitioning {
 
-    private let isPresenting: Bool
+    public var presenting: Bool
 
-    init(forPresentation isPresenting: Bool) {
-        self.isPresenting = isPresenting
+    init(forPresentation presenting: Bool) {
+        self.presenting = presenting
     }
 
     public func transitionDuration(transitionContext: UIViewControllerContextTransitioning?) -> NSTimeInterval {
@@ -130,7 +130,7 @@ public class SHDatePickerAnimatedTransition: NSObject, UIViewControllerAnimatedT
     }
 
     public func animateTransition(transitionContext: UIViewControllerContextTransitioning) {
-        if isPresenting {
+        if presenting {
             animatePresentation(transitionContext)
         } else {
             animateDismissal(transitionContext)

--- a/SwiftHelpers/SHDatePickerController.swift
+++ b/SwiftHelpers/SHDatePickerController.swift
@@ -8,8 +8,6 @@
 
 import UIKit
 
-import UIKit
-
 /*
 ** A view controller responsible for presenting a date picker to the user
 ** and pass back the selected date.

--- a/SwiftHelpers/SHDatePickerController.swift
+++ b/SwiftHelpers/SHDatePickerController.swift
@@ -1,0 +1,199 @@
+//
+//  SHDatePickerController.swift
+//  SwiftHelpers
+//
+//  Created by Maxime de Chalendar on 16/08/2016.
+//  Copyright © 2016 Wopata. All rights reserved.
+//
+
+import UIKit
+
+import UIKit
+
+/*
+** A view controller responsible for presenting a date picker to the user
+** and pass back the selected date.
+** Should be used along with the `DatePickerAnimatedTransition` custom presentation / dismissal.
+*/
+public class SHDatePickerViewController: UIViewController {
+
+    /// The date picker of the controller. Can be used to customize the mode, for example.
+    public let datePicker = UIDatePicker()
+
+    /// The background view that overlays the presenter's content. Default background is black @ 50%
+    public let background = UIView()
+
+    /// Called whenenver the view controller is dismissed. Date is `nil` unless the confirm button is tapped.
+    public var completion: (NSDate? -> Void)? = nil
+
+    private let toolbar = UIToolbar()
+    private var bottomView = UIView()
+
+    override public func viewDidLoad() {
+        super.viewDidLoad()
+
+        setupBackground()
+        setupBottomView()
+        setupDatePicker()
+        setupToolbar()
+    }
+
+    private func setupBackground() {
+        view.addSubview(background)
+        background.translatesAutoresizingMaskIntoConstraints = false
+        let hConstraints = NSLayoutConstraint.constraintsWithVisualFormat("H:|[background]|", options: NSLayoutFormatOptions(), metrics: nil, views: ["background": background])
+        let vConstraints = NSLayoutConstraint.constraintsWithVisualFormat("V:|[background]|", options: NSLayoutFormatOptions(), metrics: nil, views: ["background": background])
+        let constraints = hConstraints + vConstraints
+        view.addConstraints(constraints)
+
+        background.backgroundColor = UIColor.blackColor().colorWithAlphaComponent(0.5)
+
+        let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(tappedBackgroundView(_:)))
+        background.addGestureRecognizer(tapGestureRecognizer)
+
+        let swipeGestureRecognizer = UISwipeGestureRecognizer(target: self, action: #selector(swipedBackgroundView(_:)))
+        swipeGestureRecognizer.direction = .Down
+        background.addGestureRecognizer(swipeGestureRecognizer)
+    }
+
+    private func setupBottomView() {
+        view.addSubview(bottomView)
+        bottomView.translatesAutoresizingMaskIntoConstraints = false
+        let hConstraints = NSLayoutConstraint.constraintsWithVisualFormat("H:|[bottomView]|", options: NSLayoutFormatOptions(), metrics: nil, views: ["bottomView": bottomView])
+        let vConstraints = NSLayoutConstraint.constraintsWithVisualFormat("V:[bottomView]|", options: NSLayoutFormatOptions(), metrics: nil, views: ["bottomView": bottomView])
+        let constraints = hConstraints + vConstraints
+        view.addConstraints(constraints)
+
+        bottomView.backgroundColor = .whiteColor()
+    }
+
+    private func setupDatePicker() {
+        bottomView.addSubview(datePicker)
+        datePicker.translatesAutoresizingMaskIntoConstraints = false
+        let hConstraints = NSLayoutConstraint.constraintsWithVisualFormat("H:|[datePicker]|", options: NSLayoutFormatOptions(), metrics: nil, views: ["datePicker": datePicker])
+        let vConstraints = NSLayoutConstraint.constraintsWithVisualFormat("V:[datePicker]|", options: NSLayoutFormatOptions(), metrics: nil, views: ["datePicker": datePicker])
+        let constraints = hConstraints + vConstraints
+        view.addConstraints(constraints)
+    }
+
+    private func setupToolbar() {
+        bottomView.addSubview(toolbar)
+        toolbar.translatesAutoresizingMaskIntoConstraints = false
+        let hConstraints = NSLayoutConstraint.constraintsWithVisualFormat("H:|[toolbar]|", options: NSLayoutFormatOptions(), metrics: nil, views: ["toolbar": toolbar])
+        let vConstraints = NSLayoutConstraint.constraintsWithVisualFormat("V:|[toolbar][datePicker]", options: NSLayoutFormatOptions(), metrics: nil, views: ["toolbar": toolbar, "datePicker": datePicker])
+        let constraints = hConstraints + vConstraints
+        view.addConstraints(constraints)
+
+        let leftSpace = UIBarButtonItem(barButtonSystemItem: .FixedSpace, target: nil, action: nil)
+        leftSpace.width = 10
+        let cancelButton = UIBarButtonItem(barButtonSystemItem: .Cancel, target: self, action: #selector(tappedCancelButton(_:)))
+        let centerSpace = UIBarButtonItem(barButtonSystemItem: .FlexibleSpace, target: nil, action: nil)
+        let confirmButton = UIBarButtonItem(barButtonSystemItem: .Done, target: self, action: #selector(tappedDoneButton(_:)))
+        let rightSpace = UIBarButtonItem(barButtonSystemItem: .FixedSpace, target: nil, action: nil)
+        rightSpace.width = 10
+        toolbar.items = [leftSpace, cancelButton, centerSpace, confirmButton, rightSpace]
+    }
+
+    func tappedDoneButton(button: UIBarButtonItem) {
+        dismissWithDate(datePicker.date)
+    }
+
+    func tappedCancelButton(button: UIBarButtonItem) {
+        dismissWithDate(nil)
+    }
+
+    func tappedBackgroundView(gestureRecognizer: UITapGestureRecognizer) {
+        dismissWithDate(nil)
+    }
+
+    func swipedBackgroundView(gestureRecognizer: UISwipeGestureRecognizer) {
+        dismissWithDate(nil)
+    }
+
+    private func dismissWithDate(date: NSDate?) {
+        dismissViewControllerAnimated(true) {
+            self.completion?(date)
+        }
+    }
+
+}
+
+/// A class used to animate the transition of a SHDatePickerViewController
+public class SHDatePickerAnimatedTransition: NSObject, UIViewControllerAnimatedTransitioning {
+
+    private let isPresenting: Bool
+
+    init(forPresentation isPresenting: Bool) {
+        self.isPresenting = isPresenting
+    }
+
+    public func transitionDuration(transitionContext: UIViewControllerContextTransitioning?) -> NSTimeInterval {
+        return 0.4
+    }
+
+    public func animateTransition(transitionContext: UIViewControllerContextTransitioning) {
+        if isPresenting {
+            animatePresentation(transitionContext)
+        } else {
+            animateDismissal(transitionContext)
+        }
+    }
+
+    private func animatePresentation(transitionContext: UIViewControllerContextTransitioning) {
+        guard let container = transitionContext.containerView(),
+            datePickerController = transitionContext.viewControllerForKey(UITransitionContextToViewControllerKey) as? SHDatePickerViewController else {
+                transitionContext.completeTransition(false)
+                return
+        }
+
+        let duration = transitionDuration(transitionContext)
+
+        let datePickerView = datePickerController.view
+        container.addSubview(datePickerView)
+        let hConstraints = NSLayoutConstraint.constraintsWithVisualFormat("H:|[datePickerView]|", options: NSLayoutFormatOptions(), metrics: nil, views: ["datePickerView": datePickerView])
+        let vConstraints = NSLayoutConstraint.constraintsWithVisualFormat("V:|[datePickerView]|", options: NSLayoutFormatOptions(), metrics: nil, views: ["datePickerView": datePickerView])
+        let constraints = hConstraints + vConstraints
+        container.addConstraints(constraints)
+        container.layoutIfNeeded()
+
+        let bottomView = datePickerController.bottomView
+        bottomView.transform = CGAffineTransformMakeTranslation(0, bottomView.bounds.height)
+
+        let background = datePickerController.background
+        background.alpha = 0
+
+        UIView.animateWithDuration(duration / 3, delay: 0, options: [.CurveEaseInOut], animations: {
+            background.alpha = 1
+            }, completion: { _ in
+                UIView.animateWithDuration(duration / 3 * 2, delay: 0, options: [.CurveEaseInOut], animations: {
+                    bottomView.transform = CGAffineTransformIdentity
+                    }, completion: { _ in
+                        transitionContext.completeTransition(true)
+                })
+        })
+    }
+
+    private func animateDismissal(transitionContext: UIViewControllerContextTransitioning) {
+        guard let datePickerController = transitionContext.viewControllerForKey(UITransitionContextFromViewControllerKey) as? SHDatePickerViewController else {
+            transitionContext.completeTransition(false)
+            return
+        }
+
+        let duration = transitionDuration(transitionContext)
+        let datePickerView = datePickerController.view
+        let bottomView = datePickerController.bottomView
+        let background = datePickerController.background
+
+        UIView.animateWithDuration(duration / 3 * 2, delay: 0, options: [.CurveEaseInOut], animations: {
+            bottomView.transform = CGAffineTransformMakeTranslation(0, bottomView.bounds.height)
+            }, completion: { _ in
+                UIView.animateWithDuration(duration / 3, delay: 0, options: [.CurveEaseInOut], animations: {
+                    background.alpha = 0
+                    }, completion: { _ in
+                        datePickerView.removeFromSuperview()
+                        transitionContext.completeTransition(true)
+                })
+        })
+    }
+    
+}


### PR DESCRIPTION
Added a view controller that can be presented to ask for a date / date time.
It will make the date picker appear from the bottom of the screen, just as when used as a keyboard accessory view (but can be used without a textfield).

It will also dim the presenter's view, and the overlay is configurable.

There's a confirm button, dismiss button, and it also can be dismissed by tapping or swiping outside of the datepicker.

Usage example:

```
class ViewController: UIViewController {

    @IBAction private func tappedAgeButton(sender: UIButton) {
        let controller = DatePickerViewController()
        controller.datePicker.datePickerMode = .Date
        controller.datePicker.maximumDate = NSDate()
        controller.completion = { [weak self] in
            self?.updateAgeButtonWithDate($0)
        }

        controller.modalPresentationStyle = .Custom
        controller.transitioningDelegate = self
        presentViewController(controller, animated: true, completion: nil)
    }

}

extension ViewController: UIViewControllerTransitioningDelegate {

    func animationControllerForPresentedController(presented: UIViewController, presentingController presenting: UIViewController, sourceController source: UIViewController) -> UIViewControllerAnimatedTransitioning? {
        if presented is SHDatePickerViewController {
            return SHDatePickerAnimatedTransition(forPresentation: true)
        }
        return nil
    }

    func animationControllerForDismissedController(dismissed: UIViewController) -> UIViewControllerAnimatedTransitioning? {
        if dismissed is SHDatePickerViewController {
            return SHDatePickerAnimatedTransition(forPresentation: false)
        }
        return nil
    }

}
```
